### PR TITLE
Allow specifying the type of parms

### DIFF
--- a/lib/__tests__/custom-params.factory.test.ts
+++ b/lib/__tests__/custom-params.factory.test.ts
@@ -19,15 +19,18 @@ type User = {
 
 type UserWithOptionalCreatedAt = DeepPartial<User> & {
   createdAt?: DateTime;
-}
+};
 
-const userFactory = Factory.define<User, {}, User, UserWithOptionalCreatedAt>(({ params }) => {
-  const created = params.createdAt ?? DateTime.fromISO(new Date().toISOString());
-  return {
-    id: '3',
-    createdAt: created,
-  };
-});
+const userFactory = Factory.define<User, {}, User, UserWithOptionalCreatedAt>(
+  ({ params }) => {
+    const created =
+      params.createdAt ?? DateTime.fromISO(new Date().toISOString());
+    return {
+      id: '3',
+      createdAt: created,
+    };
+  },
+);
 
 describe('factory.build', () => {
   it('builds the object without params', () => {
@@ -35,7 +38,6 @@ describe('factory.build', () => {
     expect(user.id).not.toBeNull();
     expect(user.createdAt).not.toBeNull();
   });
-
 
   it('builds the object with a custom params', () => {
     const date = DateTime.fromISO('2022');

--- a/lib/__tests__/custom-params.factory.test.ts
+++ b/lib/__tests__/custom-params.factory.test.ts
@@ -1,0 +1,46 @@
+import { Factory, DeepPartial, HookFn } from 'fishery';
+
+class DateTime {
+  private constructor(public date: Date) {}
+
+  toISO(): string {
+    return this.date.toISOString();
+  }
+
+  static fromISO(iso: string): DateTime {
+    return new DateTime(new Date(iso));
+  }
+}
+
+type User = {
+  id: string;
+  createdAt: DateTime;
+};
+
+type UserWithOptionalCreatedAt = DeepPartial<User> & {
+  createdAt?: DateTime;
+}
+
+const userFactory = Factory.define<User, {}, User, UserWithOptionalCreatedAt>(({ params }) => {
+  const created = params.createdAt ?? DateTime.fromISO(new Date().toISOString());
+  return {
+    id: '3',
+    createdAt: created,
+  };
+});
+
+describe('factory.build', () => {
+  it('builds the object without params', () => {
+    const user = userFactory.build();
+    expect(user.id).not.toBeNull();
+    expect(user.createdAt).not.toBeNull();
+  });
+
+
+  it('builds the object with a custom params', () => {
+    const date = DateTime.fromISO('2022');
+    const user = userFactory.build({ createdAt: date });
+    expect(user.id).not.toBeNull();
+    expect(user.createdAt.toISO()).toEqual(date.toISO());
+  });
+});

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -8,11 +8,11 @@ import {
 } from './types';
 import { merge, mergeCustomizer } from './merge';
 
-export class FactoryBuilder<T, I, C> {
+export class FactoryBuilder<T, I, C, P> {
   constructor(
-    private generator: GeneratorFn<T, I, C>,
+    private generator: GeneratorFn<T, I, C, P>,
     private sequence: number,
-    private params: DeepPartial<T>,
+    private params: P,
     private transientParams: Partial<I>,
     private associations: Partial<T>,
     private afterBuilds: HookFn<T>[],
@@ -21,7 +21,7 @@ export class FactoryBuilder<T, I, C> {
   ) {}
 
   build() {
-    const generatorOptions: GeneratorFnOptions<T, I, C> = {
+    const generatorOptions: GeneratorFnOptions<T, I, C, P> = {
       sequence: this.sequence,
       afterBuild: this.setAfterBuild,
       afterCreate: this.setAfterCreate,

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -50,11 +50,7 @@ export class Factory<T, I = any, C = T, P = DeepPartial<T>> {
     return this.builder(params, options).build();
   }
 
-  buildList(
-    number: number,
-    params?: P,
-    options: BuildOptions<T, I> = {},
-  ): T[] {
+  buildList(number: number, params?: P, options: BuildOptions<T, I> = {}): T[] {
     let list: T[] = [];
     for (let i = 0; i < number; i++) {
       list.push(this.build(params, options));
@@ -68,10 +64,7 @@ export class Factory<T, I = any, C = T, P = DeepPartial<T>> {
    * @param params
    * @param options
    */
-  async create(
-    params?: P,
-    options: BuildOptions<T, I> = {},
-  ): Promise<C> {
+  async create(params?: P, options: BuildOptions<T, I> = {}): Promise<C> {
     return this.builder(params, options).create();
   }
 

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -9,7 +9,9 @@ export type GeneratorFnOptions<T, I, C, P> = {
   associations: Partial<T>;
   transientParams: Partial<I>;
 };
-export type GeneratorFn<T, I, C, P> = (opts: GeneratorFnOptions<T, I, C, P>) => T;
+export type GeneratorFn<T, I, C, P> = (
+  opts: GeneratorFnOptions<T, I, C, P>,
+) => T;
 export type HookFn<T> = (object: T) => any;
 export type OnCreateFn<T, C = T> = (object: T) => C | Promise<C>;
 export type AfterCreateFn<C> = (object: C) => C | Promise<C>;

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -1,15 +1,15 @@
 import { DeepPartial } from './deepPartial';
 
-export type GeneratorFnOptions<T, I, C> = {
+export type GeneratorFnOptions<T, I, C, P> = {
   sequence: number;
   afterBuild: (fn: HookFn<T>) => any;
   afterCreate: (fn: AfterCreateFn<C>) => any;
   onCreate: (fn: OnCreateFn<T, C>) => any;
-  params: DeepPartial<T>;
+  params: P;
   associations: Partial<T>;
   transientParams: Partial<I>;
 };
-export type GeneratorFn<T, I, C> = (opts: GeneratorFnOptions<T, I, C>) => T;
+export type GeneratorFn<T, I, C, P> = (opts: GeneratorFnOptions<T, I, C, P>) => T;
 export type HookFn<T> = (object: T) => any;
 export type OnCreateFn<T, C = T> = (object: T) => C | Promise<C>;
 export type AfterCreateFn<C> = (object: C) => C | Promise<C>;


### PR DESCRIPTION
## Rational
 
Like https://github.com/thoughtbot/fishery/pull/94 with `Date`, I faced a problem with some "complex" types I wanted to pass as params.

The Pull Request allows one to specify the expected type of `params` (initially `DeepPartial<T>`) so we can easily use types such as [luxon's DateTime](https://moment.github.io/luxon) without altering the library (unlike https://github.com/thoughtbot/fishery/pull/94).

_Note: For backward compatibility, `P` (type of params) was of course defaulted to `DeepPartial<T>`._

## Example

### Before

The library used to prevent this:
```typescript
import { DateTime } from 'luxon';

type Event = {
  id: string;
  createdAt: DateTime;
}

export class EventFactory extends Factory<Event> {}

export const eventFactory = EventFactory.define(({ params }) => {
  const createdAt = createdAt ?? DateTime.fromJSDate(faker.date.soon());

  return {
    id: '1',
    createdAt,
  };
});
```

`params#createdAt` was a `DeepPartial<DateTime>`, which prevent the pattern `const createdAt = createdAt ?? DateTime.fromJSDate(faker.date.soon());`

### After

```typescript
import { DateTime } from 'luxon';

type Event = {
  id: string;
  createdAt: DateTime;
}

type EventParams = DeepPartial<Event> & {
  createdAt?: DateTime;
};  

export class EventFactory extends Factory<Event, {}, Event, EventParams> {}

export const eventFactory = EventFactory.define(({ params }) => {
  const createdAt = createdAt ?? DateTime.fromJSDate(faker.date.soon());

  return {
    id: '1',
    createdAt,
  };
});
```